### PR TITLE
Add Experience and Scale section to homepage

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -619,6 +619,42 @@ body.slideshow-open {
     }
 }
 
+/* Experience Evidence */
+.experience-evidence {
+    padding: 80px 0;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+}
+
+.experience-evidence h2 {
+    margin-bottom: 52px;
+}
+
+.experience-highlights {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 48px;
+}
+
+.experience-item {
+    padding-top: 24px;
+    border-top: 2px solid var(--accent);
+}
+
+.experience-item h3 {
+    font-size: clamp(17px, 1.6vw, 21px);
+    font-family: var(--font-display);
+    margin: 0 0 16px;
+    line-height: 1.3;
+}
+
+.experience-item p {
+    font-size: 16px;
+    color: var(--muted);
+    line-height: 1.7;
+    margin: 0;
+}
+
 @media (max-width: 720px) {
     .site-nav {
         display: none;
@@ -654,5 +690,14 @@ body.slideshow-open {
 
     .slideshow-image {
         width: min(320px, 80vw);
+    }
+
+    .experience-highlights {
+        grid-template-columns: 1fr;
+        gap: 36px;
+    }
+
+    .experience-evidence {
+        padding: 60px 0;
     }
 }

--- a/en/index.html
+++ b/en/index.html
@@ -127,6 +127,26 @@
             </div>
         </section>
 
+        <section class="experience-evidence">
+            <div class="container">
+                <h2>Experience and Scale</h2>
+                <div class="experience-highlights">
+                    <div class="experience-item">
+                        <h3>14+ years building digital products</h3>
+                        <p>I have worked across corporate environments and startups, leading product initiatives with a focus on real impact and long-term sustainability.</p>
+                    </div>
+                    <div class="experience-item">
+                        <h3>Team leadership and strategic decisions</h3>
+                        <p>I have been involved in architectural decisions, roadmap definition, strategic prioritization, and cross-functional coordination.</p>
+                    </div>
+                    <div class="experience-item">
+                        <h3>Long-term vision</h3>
+                        <p>I understand product as a system: business, technology, experience, and execution aligned. My focus is not shipping features, but building direction.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <section id="contact" class="section container contact">
             <div>
                 <h2>Let's build something with intent.</h2>

--- a/es/index.html
+++ b/es/index.html
@@ -127,6 +127,26 @@
             </div>
         </section>
 
+        <section class="experience-evidence">
+            <div class="container">
+                <h2>Experiencia y escala</h2>
+                <div class="experience-highlights">
+                    <div class="experience-item">
+                        <h3>+14 años construyendo producto digital</h3>
+                        <p>He trabajado en entornos corporativos y startups, liderando iniciativas de producto con foco en impacto real y sostenibilidad.</p>
+                    </div>
+                    <div class="experience-item">
+                        <h3>Liderazgo de equipos y decisiones estratégicas</h3>
+                        <p>He participado en decisiones de arquitectura, definición de roadmap, priorización estratégica y coordinación de equipos multidisciplinarios.</p>
+                    </div>
+                    <div class="experience-item">
+                        <h3>Visión de largo plazo</h3>
+                        <p>Entiendo el producto como sistema: negocio, tecnología, experiencia y ejecución alineados. Mi foco no es lanzar features, sino construir dirección.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <section id="contact" class="section container contact">
             <div>
                 <h2>Construyamos algo con criterio.</h2>


### PR DESCRIPTION
## Summary
Added a new "Experience and Scale" section to the homepage that highlights key professional achievements and capabilities. This section is implemented with responsive design and includes both English and Spanish versions.

## Key Changes
- **CSS Styling**: Added comprehensive styles for the new experience evidence section including:
  - `.experience-evidence` container with padding and borders
  - `.experience-highlights` grid layout (3 columns on desktop, 1 column on mobile)
  - `.experience-item` styling with accent top border and typography
  - Responsive breakpoint adjustments for screens ≤720px

- **HTML Content**: Added new section to both language versions:
  - English version (`en/index.html`): Three highlight items covering 14+ years of experience, team leadership, and long-term vision
  - Spanish version (`es/index.html`): Equivalent content translated to Spanish
  - Section positioned between "Focus areas" and "Contact" sections

## Implementation Details
- Uses CSS Grid with `repeat(3, 1fr)` for desktop layout, collapsing to single column on mobile
- Implements responsive typography with `clamp()` for heading sizes
- Maintains design consistency with existing color variables (`--border`, `--accent`, `--muted`)
- Includes proper spacing and typography hierarchy matching the site's design system
- Mobile breakpoint reduces padding from 80px to 60px and adjusts gap spacing

https://claude.ai/code/session_01GtbD1bDrZnBXmMUm6Gjef6