### PR TITLE
Story 2.5: Add strategic CTAs section to homepage #10

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -850,6 +850,47 @@ body.slideshow-open {
     margin: 0;
 }
 
+/* ── Strategic CTAs ───────────────────────────────────── */
+.strategic-cta {
+    padding: 80px 0;
+    border-top: 1px solid var(--border);
+}
+
+.strategic-cta > .container > h2 {
+    margin-bottom: 48px;
+}
+
+.cta-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 32px;
+}
+
+.cta-card {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 36px 32px;
+    border-radius: var(--radius-lg);
+    background: var(--glass);
+    border: 1px solid var(--border);
+}
+
+.cta-card h3 {
+    font-size: 19px;
+    font-family: var(--font-display);
+    margin: 0;
+    line-height: 1.3;
+}
+
+.cta-card p {
+    font-size: 15px;
+    color: var(--muted);
+    line-height: 1.7;
+    margin: 0;
+    flex: 1;
+}
+
 @media (max-width: 720px) {
     .hero {
         padding: 64px 0 48px;
@@ -942,6 +983,15 @@ body.slideshow-open {
     }
 
     .experience-evidence {
+        padding: 60px 0;
+    }
+
+    .cta-grid {
+        grid-template-columns: 1fr;
+        gap: 20px;
+    }
+
+    .strategic-cta {
         padding: 60px 0;
     }
 }

--- a/en/index.html
+++ b/en/index.html
@@ -159,6 +159,29 @@
             </div>
         </section>
 
+        <section class="strategic-cta">
+            <div class="container">
+                <h2>Let's work on what truly matters</h2>
+                <div class="cta-grid">
+                    <div class="cta-card">
+                        <h3>Strategic Advisor</h3>
+                        <p>If you're building a startup and need product judgment, strategic direction, and decision clarity.</p>
+                        <a href="/en/contact/#advisor" class="btn-primary">Start a conversation</a>
+                    </div>
+                    <div class="cta-card">
+                        <h3>Startup Partnership</h3>
+                        <p>If you're looking for a product-focused partner with real execution experience to build something long-term.</p>
+                        <a href="/en/contact/#partnership" class="btn-primary">Explore collaboration</a>
+                    </div>
+                    <div class="cta-card">
+                        <h3>App Support</h3>
+                        <p>If you use one of my products and need assistance or want to share feedback.</p>
+                        <a href="/en/contact/#support" class="btn-secondary">Go to support</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <section id="contact" class="section container contact">
             <div>
                 <h2>Let's build something with intent.</h2>

--- a/es/index.html
+++ b/es/index.html
@@ -159,6 +159,29 @@
             </div>
         </section>
 
+        <section class="strategic-cta">
+            <div class="container">
+                <h2>Trabajemos en lo que realmente importa</h2>
+                <div class="cta-grid">
+                    <div class="cta-card">
+                        <h3>Advisor Estratégico</h3>
+                        <p>Si estás construyendo una startup y necesitas criterio en producto, dirección estratégica y claridad de decisiones.</p>
+                        <a href="/es/contact/#advisor" class="btn-primary">Iniciar conversación</a>
+                    </div>
+                    <div class="cta-card">
+                        <h3>Partnership en Startup</h3>
+                        <p>Si buscas un socio con experiencia en producto y ejecución real para construir algo con visión de largo plazo.</p>
+                        <a href="/es/contact/#partnership" class="btn-primary">Explorar colaboración</a>
+                    </div>
+                    <div class="cta-card">
+                        <h3>Soporte de Aplicaciones</h3>
+                        <p>Si utilizas alguno de mis productos y necesitas asistencia o quieres enviar feedback.</p>
+                        <a href="/es/contact/#support" class="btn-secondary">Ir a soporte</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <section id="contact" class="section container contact">
             <div>
                 <h2>Construyamos algo con criterio.</h2>


### PR DESCRIPTION
# Story 2.5: Add strategic CTAs section to homepage #10 

## Summary
Added a new "Strategic CTAs" section to the homepage that presents three key service offerings (Strategic Advisor, Startup Partnership, and App Support) in a visually distinct card-based layout.

## Key Changes
- **CSS Styling**: Added `.strategic-cta`, `.cta-grid`, and `.cta-card` classes with a modern glass-morphism design
  - 3-column grid layout on desktop, responsive to single column on mobile (≤720px)
  - Consistent spacing, typography, and border styling using design system variables
  - Proper padding and gap adjustments for mobile responsiveness

- **HTML Content**: Added new section to both English and Spanish homepage versions
  - Section positioned between the "Experience & Evidence" section and the contact section
  - Three service cards with headings, descriptions, and contextual CTAs
  - Links route to specific contact form anchors (#advisor, #partnership, #support)
  - Uses existing button styles (btn-primary and btn-secondary)

- **Localization**: Full Spanish translation of all content and CTAs

## Implementation Details
- Leverages existing design tokens (--border, --glass, --radius-lg, --font-display, --muted)
- Mobile breakpoint at 720px reduces grid to single column with adjusted spacing
- Cards use flexbox with `flex: 1` on paragraph text to ensure consistent heights
- Maintains visual hierarchy with h2 heading and h3 card titles

https://claude.ai/code/session_01SZoJVJhDgXFBJLGSp2kSo6