### PR TITLE
Feature/Epic 5 – Story 5.1: Hero Personal en About (ES/EN)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -217,6 +217,27 @@ body[data-theme="android"] .site-header {
     color: var(--accent);
 }
 
+/* ── About Hero ───────────────────────────────────────── */
+.about-hero {
+    padding: 80px 0 64px;
+}
+
+.about-role {
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--muted);
+    margin: 0 0 24px;
+    line-height: 1.4;
+}
+
+.about-intro {
+    font-size: 17px;
+    color: var(--muted);
+    line-height: 1.7;
+    max-width: 600px;
+    margin: 0;
+}
+
 /* ── Featured Product ─────────────────────────────────── */
 .featured-product {
     padding: 72px 0;
@@ -1278,6 +1299,10 @@ body.slideshow-open {
 }
 
 @media (max-width: 720px) {
+    .about-hero {
+        padding: 56px 0 40px;
+    }
+
     .hero {
         padding: 64px 0 48px;
     }

--- a/assets/js/include-loader.js
+++ b/assets/js/include-loader.js
@@ -89,7 +89,7 @@
         const links = {
             home:     base,
             projects: `${base}projects/`,
-            about:    `${base}#about`,
+            about:    `${base}about/`,
             contact:  `${base}#contact`,
             privacy:  `${base}privacy/`,
         };

--- a/en/about/index.html
+++ b/en/about/index.html
@@ -12,6 +12,14 @@
     <div class="ambient"></div>
     <div data-include="header"></div>
 
+    <section class="about-hero">
+        <div class="container">
+            <h1>Matías Fernández</h1>
+            <p class="about-role">Senior Product Builder & Strategic Advisor</p>
+            <p class="about-intro">I work at the intersection of business and technology, leading product direction with clarity and real execution.</p>
+        </div>
+    </section>
+
     <main class="section container split">
         <div>
             <h2>About</h2>

--- a/es/about/index.html
+++ b/es/about/index.html
@@ -12,6 +12,14 @@
     <div class="ambient"></div>
     <div data-include="header"></div>
 
+    <section class="about-hero">
+        <div class="container">
+            <h1>Matías Fernández</h1>
+            <p class="about-role">Senior Product Builder & Advisor Estratégico</p>
+            <p class="about-intro">Trabajo en la intersección entre negocio y tecnología, liderando producto con foco en dirección, claridad y ejecución real.</p>
+        </div>
+    </section>
+
     <main class="section container split">
         <div>
             <h2>Sobre mi</h2>


### PR DESCRIPTION
## Summary

- Implementa sección `about-hero` en `/es/about/` y `/en/about/` con H1, rol e intro según spec del issue #33
- Agrega estilos CSS para `.about-hero`, `.about-role` y `.about-intro` (incluye responsive ≤720px)
- Fix: el link "About" en la navbar apuntaba al anchor `#about` de la home en lugar de `about/`

## Closes

Closes #33

## Test plan

- [ ] Abrir `/es/about/` — Hero visible con copy exacto en español
- [ ] Abrir `/en/about/` — Hero visible con copy exacto en inglés
- [ ] Verificar que el link "Sobre mi / About" en la navbar navega correctamente
- [ ] Verificar responsive en mobile (≤720px)
- [ ] Confirmar que no hay overflow horizontal ni errores en consola

🤖 Generated with [Claude Code](https://claude.com/claude-code)