### PR TITLE
[codex] Reposition site toward technical leadership

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1263,6 +1263,10 @@ body.slideshow-open {
 
 .product-cta {
     margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: fit-content;
 }
 
 .app-store-link {
@@ -1276,9 +1280,10 @@ body.slideshow-open {
 }
 
 .app-store-badge {
-    height: 40px;
+    height: auto;
     width: auto;
     display: block;
+    max-height: 60px;
 }
 
 .product-hero-image {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -204,6 +204,29 @@ body[data-theme="android"] .site-header {
     box-shadow: 0 16px 30px color-mix(in srgb, var(--accent) 45%, transparent);
 }
 
+.credibility-strip {
+    padding: 0 0 72px;
+}
+
+.credibility-grid {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.credibility-item {
+    margin: 0;
+    padding: 18px 20px;
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.56);
+    border: 1px solid var(--border);
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.5;
+    color: var(--ink);
+    text-wrap: balance;
+}
+
 .btn-secondary {
     padding: 14px 28px;
     border-radius: var(--radius-pill);
@@ -520,6 +543,41 @@ body[data-theme="android"] .site-header {
     color: var(--muted);
     line-height: 1.7;
     margin: 0;
+}
+
+/* ── How I Work ──────────────────────────────────────── */
+.how-i-work {
+    padding: 0 0 80px;
+    border-bottom: 1px solid var(--border);
+}
+
+.how-i-work h2 {
+    margin-bottom: 20px;
+}
+
+.how-i-work-intro {
+    max-width: 760px;
+    font-size: 17px;
+    color: var(--muted);
+    line-height: 1.75;
+    margin: 0 0 32px;
+}
+
+.how-i-work-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.how-i-work-item {
+    margin: 0;
+    padding: 18px 20px;
+    border-radius: var(--radius-md);
+    background: var(--glass);
+    border: 1px solid var(--border);
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--ink);
 }
 
 
@@ -1618,6 +1676,14 @@ body.slideshow-open {
         gap: 20px;
     }
 
+    .credibility-strip {
+        padding: 0 0 48px;
+    }
+
+    .credibility-grid {
+        grid-template-columns: 1fr;
+    }
+
     .hero-description {
         margin: 0;
     }
@@ -1690,6 +1756,14 @@ body.slideshow-open {
 
     .experience-evidence {
         padding: 60px 0;
+    }
+
+    .how-i-work {
+        padding: 0 0 60px;
+    }
+
+    .how-i-work-grid {
+        grid-template-columns: 1fr;
     }
 
     .cta-grid {

--- a/en/about/index.html
+++ b/en/about/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About – Matías Fernández</title>
-    <meta name="description" content="Senior Product Builder & Strategic Advisor. Experience in product strategy, structural decisions, and product building." />
+    <meta name="description" content="Senior technical product builder with mobile architecture depth, technical leadership experience, and practical AI-enabled execution." />
     <link rel="canonical" href="https://matiasrfernandez.com/en/about/" />
     <link rel="alternate" hreflang="es" href="https://matiasrfernandez.com/es/about/" />
     <link rel="alternate" hreflang="en" href="https://matiasrfernandez.com/en/about/" />
     <link rel="alternate" hreflang="x-default" href="https://matiasrfernandez.com/en/about/" />
     <!-- Open Graph -->
     <meta property="og:title" content="About – Matías Fernández" />
-    <meta property="og:description" content="Senior Product Builder & Strategic Advisor. Experience in product strategy, structural decisions, and product building." />
+    <meta property="og:description" content="Senior technical product builder with mobile architecture depth, technical leadership experience, and practical AI-enabled execution." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://matiasrfernandez.com/en/about/" />
     <meta property="og:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
@@ -19,7 +19,7 @@
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="About – Matías Fernández" />
-    <meta name="twitter:description" content="Senior Product Builder & Strategic Advisor. Experience in product strategy, structural decisions, and product building." />
+    <meta name="twitter:description" content="Senior technical product builder with mobile architecture depth, technical leadership experience, and practical AI-enabled execution." />
     <meta name="twitter:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <link rel="stylesheet" href="../../assets/css/style.css">
     <script src="../../assets/js/theme.js" defer></script>
@@ -35,8 +35,8 @@
     <section class="about-hero">
         <div class="container">
             <h1>Matías Fernández</h1>
-            <p class="about-role">Senior Product Builder & Strategic Advisor</p>
-            <p class="about-intro">I work at the intersection of business and technology, leading product direction with clarity and real execution.</p>
+            <p class="about-role">Senior technical product builder focused on mobile architecture, technical leadership, and AI-enabled execution.</p>
+            <p class="about-intro">I work where product, engineering, and strategy meet, combining native mobile depth with delivery leadership and hands-on building.</p>
         </div>
     </section>
 
@@ -44,49 +44,49 @@
         <div class="container">
             <h2>Professional Experience</h2>
             <div class="about-experience-content">
-                <p>I have spent over 14 years building and scaling digital products across corporate environments and startups. I have worked in high-complexity contexts, with distributed teams and ambitious objectives.</p>
-                <p>I have been involved in initiatives requiring a balance between business vision, technical decisions, and coordinated execution. My role evolved from direct building to strategic definition and product leadership.</p>
-                <p>My experience combines technical depth with product judgment, allowing me to operate both at the architectural level and in roadmap definition, always focused on real impact.</p>
+                <p>I have spent more than 14 years building and scaling mobile and digital products across startups and corporate environments, in contexts that required both technical depth and product judgment.</p>
+                <p>My background started in direct building and evolved into architecture definition, technical leadership, cross-functional execution, and the systems needed to ship reliably.</p>
+                <p>That combination lets me operate from native iOS foundations and API structure up to roadmap trade-offs, team clarity, and delivery quality, always focused on practical outcomes.</p>
             </div>
         </div>
     </section>
 
     <section class="about-decisions">
         <div class="container">
-            <h2>Types of Decisions I Make</h2>
-            <div class="decision-grid">
-                <div class="decision-item">
-                    <h3>Product Direction</h3>
-                    <p>I define priorities, decision frameworks, and strategic direction in uncertain environments, aligning business, technology, and experience.</p>
-                </div>
-                <div class="decision-item">
-                    <h3>Architecture and Scalability</h3>
-                    <p>I make decisions that impact technical sustainability, performance, and long-term product growth.</p>
-                </div>
-                <div class="decision-item">
-                    <h3>Prioritization and Focus</h3>
-                    <p>I evaluate what not to build with the same clarity as what to build, protecting focus and avoiding unnecessary complexity.</p>
+                <h2>Where I Add Leverage</h2>
+                <div class="decision-grid">
+                    <div class="decision-item">
+                        <h3>Mobile and Product Architecture</h3>
+                        <p>I help define native foundations, modular boundaries, API contracts, release quality, performance priorities, and the technical trade-offs that shape long-term product health.</p>
+                    </div>
+                    <div class="decision-item">
+                        <h3>Technical Leadership and Delivery Systems</h3>
+                        <p>I improve engineering clarity through standards, CI/CD, release readiness, mentoring, and cross-functional alignment that make teams more reliable over time.</p>
+                    </div>
+                    <div class="decision-item">
+                        <h3>AI Leverage and Prioritization</h3>
+                        <p>I apply AI and automation where they improve discovery, documentation, execution speed, and decision quality without adding superficial complexity.</p>
+                    </div>
                 </div>
             </div>
-        </div>
-    </section>
+        </section>
 
     <section class="about-philosophy">
         <div class="container">
-            <h2>Product Philosophy</h2>
-            <p class="philosophy-intro">I understand product as a system where business, technology, and experience must align. Clarity precedes complexity.</p>
+            <h2>Working Principles</h2>
+            <p class="philosophy-intro">I believe strong product work comes from aligned systems: architecture, delivery, user value, and decision-making working together.</p>
             <div class="philosophy-principles">
                 <div class="philosophy-item">
-                    <h3>Simplicity as Strategy</h3>
-                    <p>Reducing complexity is not an aesthetic decision, but a strategic one. Every unnecessary layer impacts focus and sustainability.</p>
+                    <h3>Practical Depth</h3>
+                    <p>Technical quality matters when it improves leverage, reliability, and the ability to keep shipping with confidence.</p>
                 </div>
                 <div class="philosophy-item">
-                    <h3>Direction Before Speed</h3>
-                    <p>I prefer moving forward with clarity rather than accelerating without judgment. Speed without direction creates strategic debt.</p>
+                    <h3>Clarity Before Complexity</h3>
+                    <p>Architecture, process, and scope should reduce noise, preserve focus, and make better decisions easier to sustain.</p>
                 </div>
                 <div class="philosophy-item">
-                    <h3>Systems, Not Features</h3>
-                    <p>Building product means designing coherent systems, not accumulating isolated features.</p>
+                    <h3>Build to Learn</h3>
+                    <p>Hands-on execution keeps judgment honest. I prefer decisions tested in real products, workflows, and delivery constraints.</p>
                 </div>
             </div>
         </div>
@@ -94,18 +94,18 @@
 
     <section class="about-mentoring">
         <div class="container">
-            <h2>Mentoring and Reflection</h2>
-            <p>On an ad honorem basis, I support founders and product professionals seeking strategic clarity. I am particularly interested in discussing difficult decisions, product architecture, and long-term direction. In the future, this space may evolve into public conversations or a podcast format focused on judgment and real-world building.</p>
+            <h2>Technical Advisory</h2>
+            <p>I collaborate selectively with teams and founders who need senior judgment across mobile architecture, product direction, delivery systems, or practical AI adoption. I am most useful where strategy needs to connect to real technical execution.</p>
         </div>
     </section>
 
     <section class="about-cta">
         <div class="container">
-            <h2>If you're building with ambition</h2>
-            <p>I'm open to conversations where product, direction, and strategic execution are central.</p>
+            <h2>If you're building something that needs technical depth</h2>
+            <p>I'm open to conversations where mobile architecture, delivery leadership, AI-enabled execution, or startup product direction are central.</p>
             <div class="about-cta-actions">
-                <a href="/en/contact/#advisor" class="btn-primary" onclick="gtag('event', 'click_advisory', {'event_category': 'engagement'});">Discuss advisory</a>
-                <a href="/en/contact/#partnership" class="btn-secondary" onclick="gtag('event', 'click_partnership', {'event_category': 'engagement'});">Explore partnership</a>
+                <a href="/en/contact/#architecture" class="btn-primary" onclick="gtag('event', 'click_advisory', {'event_category': 'engagement'});">Discuss architecture</a>
+                <a href="/en/contact/#startup" class="btn-secondary" onclick="gtag('event', 'click_partnership', {'event_category': 'engagement'});">Explore collaboration</a>
             </div>
         </div>
     </section>

--- a/en/contact/index.html
+++ b/en/contact/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Contact – Matías Fernández</title>
-    <meta name="description" content="Segmented contact for strategic advisory, partnership, and app support." />
+    <meta name="description" content="Contact for mobile architecture, technical leadership, AI solutions, startup advisory, and app support." />
     <link rel="canonical" href="https://matiasrfernandez.com/en/contact/" />
     <link rel="alternate" hreflang="es" href="https://matiasrfernandez.com/es/contact/" />
     <link rel="alternate" hreflang="en" href="https://matiasrfernandez.com/en/contact/" />
     <link rel="alternate" hreflang="x-default" href="https://matiasrfernandez.com/en/contact/" />
     <!-- Open Graph -->
     <meta property="og:title" content="Contact – Matías Fernández" />
-    <meta property="og:description" content="Segmented contact for strategic advisory, partnership, and app support." />
+    <meta property="og:description" content="Contact for mobile architecture, technical leadership, AI solutions, startup advisory, and app support." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://matiasrfernandez.com/en/contact/" />
     <meta property="og:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
@@ -19,7 +19,7 @@
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Contact – Matías Fernández" />
-    <meta name="twitter:description" content="Segmented contact for strategic advisory, partnership, and app support." />
+    <meta name="twitter:description" content="Contact for mobile architecture, technical leadership, AI solutions, startup advisory, and app support." />
     <meta name="twitter:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <link rel="stylesheet" href="../../assets/css/style.css">
     <script src="../../assets/js/theme.js" defer></script>
@@ -35,20 +35,25 @@
     <section class="contact-hero">
         <div class="container">
             <h1>Contact</h1>
-            <p class="contact-intro">If you're building with ambition and need strategic clarity, this is the starting point.</p>
+            <p class="contact-intro">If you're hiring for mobile architecture, technical leadership, AI-enabled execution, or startup product building, this is the right place to start.</p>
         </div>
     </section>
 
     <section class="contact-segmentation">
         <div class="container">
-            <div id="advisor" class="contact-block">
-                <h2>Strategic Advisory</h2>
-                <p>Conversations focused on product direction, structural decisions, and strategic clarity during growth stages.</p>
+            <div id="architecture" class="contact-block">
+                <h2>Mobile Architecture / Technical Leadership</h2>
+                <p>Conversations about native mobile foundations, architecture decisions, release quality, delivery systems, and senior technical leadership needs.</p>
                 <p class="contact-email"><a href="mailto:contact@matiasrfernandez.com">contact@matiasrfernandez.com</a></p>
             </div>
-            <div id="partnership" class="contact-block">
-                <h2>Startup Partnership</h2>
-                <p>Initiatives where product, architecture, and direction require active involvement as a strategic partner.</p>
+            <div id="ai" class="contact-block">
+                <h2>AI Solutions / Technical Advisory</h2>
+                <p>Conversations focused on practical AI adoption, automation workflows, technical documentation, engineering leverage, and delivery improvement.</p>
+                <p class="contact-email"><a href="mailto:contact@matiasrfernandez.com">contact@matiasrfernandez.com</a></p>
+            </div>
+            <div id="startup" class="contact-block">
+                <h2>Startup Technical / Product Advisory</h2>
+                <p>Initiatives where product direction, architecture, and execution need active involvement from a senior technical product builder.</p>
                 <p class="contact-email"><a href="mailto:contact@matiasrfernandez.com">contact@matiasrfernandez.com</a></p>
             </div>
             <div id="support" class="contact-block">

--- a/en/index.html
+++ b/en/index.html
@@ -3,23 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Matías Fernández – Senior Product Builder & Strategic Advisor</title>
-    <meta name="description" content="Senior Product Builder working at the intersection of business and technology. Strategic direction, judgment, and real execution." />
+    <title>Matías Fernández – Mobile Architecture, Technical Leadership & AI-Enabled Execution</title>
+    <meta name="description" content="Senior technical product builder with 14+ years in mobile and digital products. Mobile architecture, technical leadership, AI-enabled execution, and shipped iOS product proof." />
     <link rel="canonical" href="https://matiasrfernandez.com/en/" />
     <link rel="alternate" hreflang="es" href="https://matiasrfernandez.com/es/" />
     <link rel="alternate" hreflang="en" href="https://matiasrfernandez.com/en/" />
     <link rel="alternate" hreflang="x-default" href="https://matiasrfernandez.com/en/" />
     <!-- Open Graph -->
-    <meta property="og:title" content="Matías Fernández – Senior Product Builder & Strategic Advisor" />
-    <meta property="og:description" content="Senior Product Builder working at the intersection of business and technology. Strategic direction, judgment, and real execution." />
+    <meta property="og:title" content="Matías Fernández – Mobile Architecture, Technical Leadership & AI-Enabled Execution" />
+    <meta property="og:description" content="Senior technical product builder with 14+ years in mobile and digital products. Mobile architecture, technical leadership, AI-enabled execution, and shipped iOS product proof." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://matiasrfernandez.com/en/" />
     <meta property="og:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <meta property="og:locale" content="en_US" />
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Matías Fernández – Senior Product Builder & Strategic Advisor" />
-    <meta name="twitter:description" content="Senior Product Builder working at the intersection of business and technology. Strategic direction, judgment, and real execution." />
+    <meta name="twitter:title" content="Matías Fernández – Mobile Architecture, Technical Leadership & AI-Enabled Execution" />
+    <meta name="twitter:description" content="Senior technical product builder with 14+ years in mobile and digital products. Mobile architecture, technical leadership, AI-enabled execution, and shipped iOS product proof." />
     <meta name="twitter:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <link rel="stylesheet" href="../assets/css/style.css">
     <script src="../assets/js/theme.js" defer></script>
@@ -35,12 +35,25 @@
     <main id="top">
         <section class="hero">
             <div class="hero-container">
-                <h1>I build and lead digital products with strategic clarity.</h1>
-                <p class="hero-subtitle">Senior Product Builder and Advisor for startups ready to scale.</p>
-                <p class="hero-description">I work at the intersection of business and technology. I make strategic decisions, lead product direction, and build real solutions as proof of execution.</p>
+                <h1>Mobile Architecture, Technical Leadership, and AI-Enabled Execution.</h1>
+                <p class="hero-subtitle">I help teams build better digital products through mobile architecture, technical leadership, and AI-enabled execution.</p>
+                <p class="hero-description">I work at the intersection of product, engineering, and strategy, with 14+ years building mobile and digital products, leading technical teams, defining architecture, and turning ideas into shipped software.</p>
                 <div class="hero-cta">
-                    <a href="contact/" class="btn-primary">Discuss Strategy</a>
+                    <a href="contact/#architecture" class="btn-primary">Discuss a Role or Project</a>
                     <a href="projects/" class="btn-secondary">View Projects</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="credibility-strip">
+            <div class="container">
+                <h2 class="sr-only">Credibility Highlights</h2>
+                <div class="credibility-grid">
+                    <p class="credibility-item">14+ years building digital products</p>
+                    <p class="credibility-item">Native mobile architecture</p>
+                    <p class="credibility-item">Technical leadership and delivery systems</p>
+                    <p class="credibility-item">Shipped iOS products</p>
+                    <p class="credibility-item">Practical AI and automation workflows</p>
                 </div>
             </div>
         </section>
@@ -50,7 +63,7 @@
                 <div class="featured-product-content">
                     <div class="featured-product-text">
                         <h2>Dolar+</h2>
-                        <p class="product-description">An exchange rate tracking app focused on the Argentine dollar, designed with clarity, precision, and real user experience in mind.</p>
+                        <p class="product-description">Dolar+ is a native iOS product for Argentine exchange rates, built with SwiftUI, modular architecture, real-time exchange rate APIs, widgets, Apple ecosystem integrations, and a privacy-conscious product approach.</p>
                         <p class="product-status">Status: Live</p>
                         <a href="projects/dolarplus/" class="btn-primary">View Product</a>
                     </div>
@@ -66,36 +79,50 @@
                 <h2>What I Do</h2>
                 <div class="what-i-do-grid">
                     <div class="what-i-do-item">
-                        <h3>Product Strategy</h3>
-                        <p>I define direction, priorities, and decision frameworks. I focus on real impact and strategic clarity rather than endless feature lists.</p>
+                        <h3>Mobile &amp; Product Architecture</h3>
+                        <p>I help define mobile and digital product architecture: native iOS foundations, modular structure, APIs, performance, release quality, and long-term technical decisions.</p>
                     </div>
                     <div class="what-i-do-item">
-                        <h3>Business–Technology Leadership</h3>
-                        <p>I connect business vision with technical execution. I translate ambition into concrete roadmaps and sustainable decisions.</p>
+                        <h3>Technical Leadership &amp; Delivery Systems</h3>
+                        <p>I create clarity across engineering teams through technical standards, CI/CD, release readiness, architecture alignment, mentoring, and cross-functional execution.</p>
                     </div>
                     <div class="what-i-do-item">
-                        <h3>Building as Proof</h3>
-                        <p>I don't only advise. I build my own products to validate judgment, experiment, and stay close to real execution.</p>
+                        <h3>AI-Enabled Execution</h3>
+                        <p>I use practical AI and automation to improve product discovery, engineering workflows, technical documentation, delivery speed, and decision quality.</p>
                     </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="how-i-work">
+            <div class="container">
+                <h2>How I Work</h2>
+                <p class="how-i-work-intro">I combine product judgment with technical execution. I clarify the real problem, define architecture and trade-offs, build or guide the first implementation, create delivery systems and technical standards, and use AI where it improves speed, quality, or leverage.</p>
+                <div class="how-i-work-grid">
+                    <p class="how-i-work-item">Clarify the real product and technical problem</p>
+                    <p class="how-i-work-item">Define architecture, constraints, and trade-offs</p>
+                    <p class="how-i-work-item">Build or guide implementation</p>
+                    <p class="how-i-work-item">Create standards, delivery systems, and feedback loops</p>
+                    <p class="how-i-work-item">Apply AI where it creates practical leverage</p>
                 </div>
             </div>
         </section>
 
         <section class="experience-evidence">
             <div class="container">
-                <h2>Experience and Scale</h2>
+                <h2>Execution and Technical Credibility</h2>
                 <div class="experience-highlights">
                     <div class="experience-item">
-                        <h3>14+ years building digital products</h3>
-                        <p>I have worked across corporate environments and startups, leading product initiatives with a focus on real impact and long-term sustainability.</p>
+                        <h3>Mobile architecture with product context</h3>
+                        <p>I work from native iOS foundations upward: modular structure, API boundaries, release quality, performance, and the trade-offs that shape long-term product health.</p>
                     </div>
                     <div class="experience-item">
-                        <h3>Team leadership and strategic decisions</h3>
-                        <p>I have been involved in architectural decisions, roadmap definition, strategic prioritization, and cross-functional coordination.</p>
+                        <h3>Technical leadership that improves delivery</h3>
+                        <p>I help teams create clarity through standards, CI/CD, release readiness, mentoring, and cross-functional alignment, so execution scales without unnecessary complexity.</p>
                     </div>
                     <div class="experience-item">
-                        <h3>Long-term vision</h3>
-                        <p>I understand product as a system: business, technology, experience, and execution aligned. My focus is not shipping features, but building direction.</p>
+                        <h3>Shipped software as current proof</h3>
+                        <p>I use products like Dolar+ to stay close to real implementation, App Store constraints, product decisions, and the details that separate ideas from working software.</p>
                     </div>
                 </div>
             </div>
@@ -103,22 +130,22 @@
 
         <section class="strategic-cta">
             <div class="container">
-                <h2>Let's work on what truly matters</h2>
+                <h2>Ways I Can Help</h2>
                 <div class="cta-grid">
                     <div class="cta-card">
-                        <h3>Strategic Advisor</h3>
-                        <p>If you're building a startup and need product judgment, strategic direction, and decision clarity.</p>
-                        <a href="/en/contact/#advisor" class="btn-primary" onclick="gtag('event', 'click_advisory', {'event_category': 'engagement'});">Start a conversation</a>
+                        <h3>Staff / Principal / Mobile Architecture</h3>
+                        <p>For teams that need stronger native mobile architecture, better technical foundations, and senior product-engineering judgment.</p>
+                        <a href="/en/contact/#architecture" class="btn-primary" onclick="gtag('event', 'click_advisory', {'event_category': 'engagement'});">Discuss a role</a>
                     </div>
                     <div class="cta-card">
-                        <h3>Startup Partnership</h3>
-                        <p>If you're looking for a product-focused partner with real execution experience to build something long-term.</p>
-                        <a href="/en/contact/#partnership" class="btn-primary" onclick="gtag('event', 'click_partnership', {'event_category': 'engagement'});">Explore collaboration</a>
+                        <h3>AI Solutions / Technical Advisory</h3>
+                        <p>For organizations applying AI and automation to product discovery, engineering workflows, technical documentation, and delivery systems.</p>
+                        <a href="/en/contact/#ai" class="btn-primary" onclick="gtag('event', 'click_advisory', {'event_category': 'engagement'});">Discuss AI delivery</a>
                     </div>
                     <div class="cta-card">
-                        <h3>App Support</h3>
-                        <p>If you use one of my products and need assistance or want to share feedback.</p>
-                        <a href="/en/contact/#support" class="btn-secondary">Go to support</a>
+                        <h3>Startup Technical / Product Advisory</h3>
+                        <p>For founders who need a senior technical product builder to shape architecture, de-risk decisions, and move from concept to shipped product.</p>
+                        <a href="/en/contact/#startup" class="btn-secondary" onclick="gtag('event', 'click_partnership', {'event_category': 'engagement'});">Explore collaboration</a>
                     </div>
                 </div>
             </div>

--- a/en/projects/dolarplus/index.html
+++ b/en/projects/dolarplus/index.html
@@ -43,6 +43,9 @@
                         <a href="https://apps.apple.com/app/id6473115030" class="app-store-link" target="_blank" rel="noopener" onclick="gtag('event', 'click_app_store', {'event_category': 'engagement', 'event_label': 'dolarplus'});">
                             <img class="app-store-badge" src="../../../assets/images/app-store/app-store-badge-en.svg" alt="Download on the App Store">
                         </a>
+                        <a href="https://www.producthunt.com/products/dolar?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-dollar-2" target="_blank" rel="noopener noreferrer">
+                            <img alt="Dollar+ - The app Argentinians who save in USD have been waiting for. | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1086595&theme=light&t=1772275499785">
+                        </a>
                     </div>
                 </div>
                 <div class="product-hero-image">
@@ -121,11 +124,6 @@
             <div class="container">
                 <h2>Links</h2>
                 <ul class="product-links-list">
-                    <li>
-                        <a href="https://apps.apple.com/app/id6473115030" class="app-store-link" target="_blank" rel="noopener" onclick="gtag('event', 'click_app_store', {'event_category': 'engagement', 'event_label': 'dolarplus'});">
-                            <img class="app-store-badge" src="../../../assets/images/app-store/app-store-badge-en.svg" alt="Download on the App Store">
-                        </a>
-                    </li>
                     <li><a href="/en/contact/#support">Support</a></li>
                     <li><a href="/en/privacy/apps/dolarplus/">Privacy Policy</a></li>
                 </ul>

--- a/en/projects/dolarplus/index.html
+++ b/en/projects/dolarplus/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dolar+ – Product – Matías Fernández</title>
-    <meta name="description" content="iOS app for Argentine dollar exchange rates, conversion, and historical tracking, designed with clarity and precision." />
+    <meta name="description" content="Native iOS product for Argentine exchange rates, built with SwiftUI, modular architecture, real-time APIs, widgets, and a focused product experience." />
     <link rel="canonical" href="https://matiasrfernandez.com/en/projects/dolarplus/" />
     <link rel="alternate" hreflang="es" href="https://matiasrfernandez.com/es/projects/dolarplus/" />
     <link rel="alternate" hreflang="en" href="https://matiasrfernandez.com/en/projects/dolarplus/" />
     <link rel="alternate" hreflang="x-default" href="https://matiasrfernandez.com/en/projects/dolarplus/" />
     <!-- Open Graph -->
     <meta property="og:title" content="Dolar+ – Product – Matías Fernández" />
-    <meta property="og:description" content="iOS app for Argentine dollar exchange rates, conversion, and historical tracking, designed with clarity and precision." />
+    <meta property="og:description" content="Native iOS product for Argentine exchange rates, built with SwiftUI, modular architecture, real-time APIs, widgets, and a focused product experience." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://matiasrfernandez.com/en/projects/dolarplus/" />
     <meta property="og:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
@@ -19,7 +19,7 @@
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Dolar+ – Product – Matías Fernández" />
-    <meta name="twitter:description" content="iOS app for Argentine dollar exchange rates, conversion, and historical tracking, designed with clarity and precision." />
+    <meta name="twitter:description" content="Native iOS product for Argentine exchange rates, built with SwiftUI, modular architecture, real-time APIs, widgets, and a focused product experience." />
     <meta name="twitter:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <link rel="stylesheet" href="../../../assets/css/style.css">
     <script src="../../../assets/js/theme.js" defer></script>
@@ -37,8 +37,8 @@
             <div class="container product-hero-content">
                 <div class="product-hero-text">
                     <h1>Dolar+</h1>
-                    <p class="product-tagline">Argentine dollar exchange rates with clarity and precision.</p>
-                    <p class="product-description">Dolar+ was built to provide fast access to reliable exchange rates, with a clean experience and no unnecessary noise.</p>
+                    <p class="product-tagline">Native iOS product for Argentine exchange rates, built for clarity, speed, and reliable daily use.</p>
+                    <p class="product-description">Dolar+ is current proof of native iOS execution: built with SwiftUI, modular architecture, real-time exchange rate integrations, widgets, and a privacy-conscious product approach designed for everyday decision-making.</p>
                     <div class="product-cta">
                         <a href="https://apps.apple.com/app/id6473115030" class="app-store-link" target="_blank" rel="noopener" onclick="gtag('event', 'click_app_store', {'event_category': 'engagement', 'event_label': 'dolarplus'});">
                             <img class="app-store-badge" src="../../../assets/images/app-store/app-store-badge-en.svg" alt="Download on the App Store">
@@ -73,19 +73,19 @@
         <section class="product-value">
             <div class="container">
                 <h2>Value Proposition</h2>
-                <p class="value-intro">Dolar+ was designed prioritizing clarity, speed, and trust. Every decision aims to reduce friction and remove unnecessary noise.</p>
+                <p class="value-intro">Dolar+ was designed as a focused native product: fast to read, technically maintainable, and deliberately low-noise.</p>
                 <div class="value-points">
                     <div class="value-item">
-                        <h3>Clarity over volume</h3>
-                        <p>The interface focuses on essential information instead of overwhelming users with excessive data.</p>
+                        <h3>Focused core flow</h3>
+                        <p>The product turns a repetitive financial check into a fast, readable experience instead of a cluttered market dashboard.</p>
                     </div>
                     <div class="value-item">
-                        <h3>Fast access</h3>
-                        <p>Exchange rates are available immediately, without complex navigation or unnecessary steps.</p>
+                        <h3>Native ecosystem fit</h3>
+                        <p>Widgets and Apple ecosystem integrations make exchange rates available in the right context, not only inside the app.</p>
                     </div>
                     <div class="value-item">
-                        <h3>Intentional decisions</h3>
-                        <p>It avoids superfluous features. The focus is on solving the core problem properly before expanding.</p>
+                        <h3>Sustainable technical base</h3>
+                        <p>The architecture favors modular boundaries, clear data flows, and decisions that support iteration without unnecessary complexity.</p>
                     </div>
                 </div>
             </div>
@@ -104,20 +104,21 @@
         </section>
         <section class="product-stack">
             <div class="container">
-                <h2>Technical Stack</h2>
-                <p class="stack-intro">Dolar+ is built with a focus on simplicity, maintainability, and performance.</p>
+                <h2>Architecture and Technical Scope</h2>
+                <p class="stack-intro">Dolar+ is built as a real production iOS product, with attention to maintainability, performance, release quality, and ecosystem fit.</p>
                 <ul class="stack-list">
-                    <li>Native iOS built with SwiftUI.</li>
-                    <li>Modular architecture designed for clarity and testability.</li>
-                    <li>Integration with real-time exchange rate APIs.</li>
-                    <li>Widgets and extensions for the Apple ecosystem.</li>
+                    <li>Native iOS application built with SwiftUI.</li>
+                    <li>Modular architecture designed for maintainability, clear boundaries, and testability.</li>
+                    <li>Integration with real-time exchange rate APIs and data normalization.</li>
+                    <li>Widgets and Apple ecosystem integrations for fast, glanceable access.</li>
+                    <li>Product decisions shaped to stay focused, low-noise, and privacy-conscious.</li>
                 </ul>
             </div>
         </section>
         <section class="product-status-section">
             <div class="container">
                 <h2>Status</h2>
-                <p class="product-status-text">Current status: Live. Available on the App Store.</p>
+                <p class="product-status-text">Current status: Live on the App Store.</p>
             </div>
         </section>
         <section class="product-links">

--- a/en/projects/index.html
+++ b/en/projects/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Projects – Matías Fernández</title>
-    <meta name="description" content="Products built with strategic judgment: live, in progress, and explorations." />
+    <meta name="description" content="Products that show real execution: native iOS delivery, technical decisions, and active product exploration." />
     <link rel="canonical" href="https://matiasrfernandez.com/en/projects/" />
     <link rel="alternate" hreflang="es" href="https://matiasrfernandez.com/es/projects/" />
     <link rel="alternate" hreflang="en" href="https://matiasrfernandez.com/en/projects/" />
     <link rel="alternate" hreflang="x-default" href="https://matiasrfernandez.com/en/projects/" />
     <!-- Open Graph -->
     <meta property="og:title" content="Projects – Matías Fernández" />
-    <meta property="og:description" content="Products built with strategic judgment: live, in progress, and explorations." />
+    <meta property="og:description" content="Products that show real execution: native iOS delivery, technical decisions, and active product exploration." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://matiasrfernandez.com/en/projects/" />
     <meta property="og:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
@@ -19,7 +19,7 @@
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Projects – Matías Fernández" />
-    <meta name="twitter:description" content="Products built with strategic judgment: live, in progress, and explorations." />
+    <meta name="twitter:description" content="Products that show real execution: native iOS delivery, technical decisions, and active product exploration." />
     <meta name="twitter:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <link rel="stylesheet" href="../../assets/css/style.css">
     <script src="../../assets/js/theme.js" defer></script>
@@ -36,7 +36,7 @@
         <section class="projects-intro">
             <div class="container">
                 <h1>Projects</h1>
-                <p class="projects-intro-text">I build my own products as a natural extension of my work in product strategy and leadership. Each project responds to a concrete hypothesis and is part of a long-term vision.</p>
+                <p class="projects-intro-text">I build products to stay close to real execution. These projects are where product judgment, mobile architecture, and delivery systems are tested in shipped software and active explorations.</p>
             </div>
         </section>
 
@@ -53,11 +53,11 @@
 
                 <section class="projects-section live">
                     <h2>Live</h2>
-                    <p class="projects-section-text">Published products in real use.</p>
+                    <p class="projects-section-text">Published products that show current technical execution.</p>
                     <div class="projects-grid live-grid">
                         <div class="project-card">
                             <h3 class="project-title">Dolar+</h3>
-                            <p class="project-description">iOS app focused on Argentine dollar exchange rates, currency conversion, and historical tracking.</p>
+                            <p class="project-description">Native iOS product for Argentine exchange rates, built with SwiftUI, modular architecture, real-time APIs, widgets, and historical tracking.</p>
                             <p class="project-status project-status--live">Live</p>
                             <a href="/en/projects/dolarplus/" class="project-link">View Product</a>
                         </div>
@@ -66,11 +66,11 @@
 
                 <section class="projects-section in-progress">
                     <h2>In Progress</h2>
-                    <p class="projects-section-text">Active initiatives under construction.</p>
+                    <p class="projects-section-text">Active initiatives where product direction and technical foundations are still being shaped.</p>
                     <div class="projects-grid progress-grid">
                         <div class="project-card">
                             <h3 class="project-title">Next Product</h3>
-                            <p class="project-description">Initiative under development focused on solving real problems through digital product.</p>
+                            <p class="project-description">Initiative under development focused on solving real problems through product, architecture, and practical execution.</p>
                             <p class="project-status">In Progress</p>
                         </div>
                     </div>
@@ -78,11 +78,11 @@
 
                 <section class="projects-section explorations">
                     <h2>Explorations</h2>
-                    <p class="projects-section-text">Hypotheses under evaluation and experimentation.</p>
+                    <p class="projects-section-text">Hypotheses being evaluated through product thinking, technical exploration, and experimentation.</p>
                     <div class="projects-grid exploration-grid">
                         <div class="project-card">
                             <h3 class="project-title">Active Exploration</h3>
-                            <p class="project-description">Product hypothesis under strategic evaluation and conceptual validation.</p>
+                            <p class="project-description">Product hypothesis under evaluation through technical framing, concept validation, and early execution thinking.</p>
                             <p class="project-status">Exploration</p>
                         </div>
                     </div>

--- a/es/about/index.html
+++ b/es/about/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sobre mí – Matías Fernández</title>
-    <meta name="description" content="Senior Product Builder & Advisor. Experiencia en estrategia de producto, decisiones estructurales y construcción de productos." />
+    <meta name="description" content="Senior technical product builder con profundidad en arquitectura mobile, experiencia en liderazgo técnico y ejecución potenciada por AI." />
     <link rel="canonical" href="https://matiasrfernandez.com/es/about/" />
     <link rel="alternate" hreflang="es" href="https://matiasrfernandez.com/es/about/" />
     <link rel="alternate" hreflang="en" href="https://matiasrfernandez.com/en/about/" />
     <link rel="alternate" hreflang="x-default" href="https://matiasrfernandez.com/en/about/" />
     <!-- Open Graph -->
     <meta property="og:title" content="Sobre mí – Matías Fernández" />
-    <meta property="og:description" content="Senior Product Builder & Advisor. Experiencia en estrategia de producto, decisiones estructurales y construcción de productos." />
+    <meta property="og:description" content="Senior technical product builder con profundidad en arquitectura mobile, experiencia en liderazgo técnico y ejecución potenciada por AI." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://matiasrfernandez.com/es/about/" />
     <meta property="og:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
@@ -19,7 +19,7 @@
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Sobre mí – Matías Fernández" />
-    <meta name="twitter:description" content="Senior Product Builder & Advisor. Experiencia en estrategia de producto, decisiones estructurales y construcción de productos." />
+    <meta name="twitter:description" content="Senior technical product builder con profundidad en arquitectura mobile, experiencia en liderazgo técnico y ejecución potenciada por AI." />
     <meta name="twitter:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <link rel="stylesheet" href="../../assets/css/style.css">
     <script src="../../assets/js/theme.js" defer></script>
@@ -35,8 +35,8 @@
     <section class="about-hero">
         <div class="container">
             <h1>Matías Fernández</h1>
-            <p class="about-role">Senior Product Builder & Advisor Estratégico</p>
-            <p class="about-intro">Trabajo en la intersección entre negocio y tecnología, liderando producto con foco en dirección, claridad y ejecución real.</p>
+            <p class="about-role">Senior technical product builder enfocado en arquitectura mobile, liderazgo técnico y ejecución potenciada por AI.</p>
+            <p class="about-intro">Trabajo donde se cruzan producto, ingeniería y estrategia, combinando profundidad mobile nativa con liderazgo de delivery y construcción directa.</p>
         </div>
     </section>
 
@@ -44,49 +44,49 @@
         <div class="container">
             <h2>Experiencia profesional</h2>
             <div class="about-experience-content">
-                <p>Llevo más de 14 años construyendo y escalando productos digitales en entornos corporativos y startups. He trabajado en contextos de alta complejidad, con equipos distribuidos y objetivos ambiciosos.</p>
-                <p>He participado en iniciativas que requieren balancear visión de negocio, decisiones técnicas y ejecución coordinada. Mi rol ha evolucionado desde la construcción directa hasta la definición estratégica y liderazgo de producto.</p>
-                <p>Mi experiencia combina profundidad técnica con criterio de producto, lo que me permite intervenir tanto en arquitectura como en roadmap, siempre con foco en impacto real.</p>
+                <p>Llevo más de 14 años construyendo y escalando productos mobile y digitales en startups y entornos corporativos, en contextos que exigían tanto profundidad técnica como criterio de producto.</p>
+                <p>Mi recorrido empezó en la construcción directa y evolucionó hacia definición de arquitectura, liderazgo técnico, ejecución cross-functional y sistemas de delivery para publicar con confiabilidad.</p>
+                <p>Esa combinación me permite moverme desde bases nativas de iOS y estructura de APIs hasta trade-offs de roadmap, claridad de equipo y calidad de ejecución, siempre con foco en resultados prácticos.</p>
             </div>
         </div>
     </section>
 
     <section class="about-decisions">
         <div class="container">
-            <h2>Tipo de decisiones que tomo</h2>
-            <div class="decision-grid">
-                <div class="decision-item">
-                    <h3>Dirección de producto</h3>
-                    <p>Defino prioridades, criterios de decisión y dirección estratégica en contextos de incertidumbre, alineando negocio, tecnología y experiencia.</p>
-                </div>
-                <div class="decision-item">
-                    <h3>Arquitectura y escalabilidad</h3>
-                    <p>Tomo decisiones que impactan sostenibilidad técnica, rendimiento y capacidad de crecimiento del producto en el largo plazo.</p>
-                </div>
-                <div class="decision-item">
-                    <h3>Priorización y foco</h3>
-                    <p>Evalúo qué no hacer con la misma claridad que qué hacer, protegiendo foco y evitando complejidad innecesaria.</p>
+                <h2>Dónde aporto más valor</h2>
+                <div class="decision-grid">
+                    <div class="decision-item">
+                        <h3>Arquitectura Mobile y de Producto</h3>
+                        <p>Ayudo a definir bases nativas, límites modulares, contratos de APIs, calidad de release, prioridades de performance y los trade-offs técnicos que afectan la salud del producto a largo plazo.</p>
+                    </div>
+                    <div class="decision-item">
+                        <h3>Liderazgo Técnico y Sistemas de Delivery</h3>
+                        <p>Mejoro la claridad de ingeniería mediante estándares, CI/CD, readiness de releases, mentoring y alineación cross-functional que vuelven a los equipos más confiables.</p>
+                    </div>
+                    <div class="decision-item">
+                        <h3>AI y Priorización</h3>
+                        <p>Aplico AI y automatización donde mejoran discovery, documentación, velocidad de ejecución y calidad de decisión, sin agregar complejidad superficial.</p>
+                    </div>
                 </div>
             </div>
-        </div>
-    </section>
+        </section>
 
     <section class="about-philosophy">
         <div class="container">
-            <h2>Filosofía de producto</h2>
-            <p class="philosophy-intro">Entiendo el producto como un sistema donde negocio, tecnología y experiencia deben estar alineados. La claridad precede a la complejidad.</p>
+            <h2>Principios de trabajo</h2>
+            <p class="philosophy-intro">Creo que el mejor trabajo de producto aparece cuando arquitectura, delivery, valor para el usuario y calidad de decisión funcionan como un mismo sistema.</p>
             <div class="philosophy-principles">
                 <div class="philosophy-item">
-                    <h3>Simplicidad como estrategia</h3>
-                    <p>Reducir complejidad no es una decisión estética, es una decisión estratégica. Cada capa innecesaria impacta en foco y sostenibilidad.</p>
+                    <h3>Profundidad práctica</h3>
+                    <p>La calidad técnica importa cuando mejora capacidad de ejecución, confiabilidad y la posibilidad de seguir publicando con criterio.</p>
                 </div>
                 <div class="philosophy-item">
-                    <h3>Dirección antes que velocidad</h3>
-                    <p>Prefiero avanzar con claridad que acelerar sin criterio. La velocidad sin dirección genera deuda estratégica.</p>
+                    <h3>Claridad antes que complejidad</h3>
+                    <p>Arquitectura, proceso y alcance deberían reducir ruido, proteger foco y hacer más sostenibles las buenas decisiones.</p>
                 </div>
                 <div class="philosophy-item">
-                    <h3>Sistemas, no features</h3>
-                    <p>Construir producto implica diseñar sistemas coherentes, no acumular funcionalidades aisladas.</p>
+                    <h3>Construir para aprender</h3>
+                    <p>La ejecución directa mantiene el criterio honesto. Prefiero decisiones probadas en productos reales, workflows y restricciones de delivery.</p>
                 </div>
             </div>
         </div>
@@ -94,18 +94,18 @@
 
     <section class="about-mentoring">
         <div class="container">
-            <h2>Mentoría y reflexión</h2>
-            <p>De forma ad honorem, acompaño a founders y perfiles de producto que buscan claridad estratégica. Me interesa especialmente discutir decisiones difíciles, arquitectura de producto y dirección de largo plazo. En el futuro, este espacio puede evolucionar hacia conversaciones públicas o un formato de podcast enfocado en criterio y construcción real.</p>
+            <h2>Advisory técnico</h2>
+            <p>Colaboro selectivamente con equipos y founders que necesitan criterio senior en arquitectura mobile, dirección de producto, sistemas de delivery o adopción práctica de AI. Soy más útil donde la estrategia tiene que conectarse con la ejecución técnica real.</p>
         </div>
     </section>
 
     <section class="about-cta">
         <div class="container">
-            <h2>Si estás construyendo algo con ambición</h2>
-            <p>Estoy abierto a conversaciones donde producto, dirección y ejecución estratégica sean centrales.</p>
+            <h2>Si estás construyendo algo que necesita profundidad técnica</h2>
+            <p>Estoy abierto a conversaciones donde arquitectura mobile, liderazgo de delivery, ejecución potenciada por AI o dirección de producto para startups sean centrales.</p>
             <div class="about-cta-actions">
-                <a href="/es/contact/#advisor" class="btn-primary" onclick="gtag('event', 'click_advisory', {'event_category': 'engagement'});">Hablar sobre advisory</a>
-                <a href="/es/contact/#partnership" class="btn-secondary" onclick="gtag('event', 'click_partnership', {'event_category': 'engagement'});">Explorar partnership</a>
+                <a href="/es/contact/#architecture" class="btn-primary" onclick="gtag('event', 'click_advisory', {'event_category': 'engagement'});">Hablar de arquitectura</a>
+                <a href="/es/contact/#startup" class="btn-secondary" onclick="gtag('event', 'click_partnership', {'event_category': 'engagement'});">Explorar colaboración</a>
             </div>
         </div>
     </section>

--- a/es/contact/index.html
+++ b/es/contact/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Contacto – Matías Fernández</title>
-    <meta name="description" content="Contacto segmentado para advisory estratégico, partnership y soporte de aplicaciones." />
+    <meta name="description" content="Contacto para arquitectura mobile, liderazgo técnico, soluciones AI, advisory para startups y soporte de aplicaciones." />
     <link rel="canonical" href="https://matiasrfernandez.com/es/contact/" />
     <link rel="alternate" hreflang="es" href="https://matiasrfernandez.com/es/contact/" />
     <link rel="alternate" hreflang="en" href="https://matiasrfernandez.com/en/contact/" />
     <link rel="alternate" hreflang="x-default" href="https://matiasrfernandez.com/en/contact/" />
     <!-- Open Graph -->
     <meta property="og:title" content="Contacto – Matías Fernández" />
-    <meta property="og:description" content="Contacto segmentado para advisory estratégico, partnership y soporte de aplicaciones." />
+    <meta property="og:description" content="Contacto para arquitectura mobile, liderazgo técnico, soluciones AI, advisory para startups y soporte de aplicaciones." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://matiasrfernandez.com/es/contact/" />
     <meta property="og:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
@@ -19,7 +19,7 @@
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Contacto – Matías Fernández" />
-    <meta name="twitter:description" content="Contacto segmentado para advisory estratégico, partnership y soporte de aplicaciones." />
+    <meta name="twitter:description" content="Contacto para arquitectura mobile, liderazgo técnico, soluciones AI, advisory para startups y soporte de aplicaciones." />
     <meta name="twitter:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <link rel="stylesheet" href="../../assets/css/style.css">
     <script src="../../assets/js/theme.js" defer></script>
@@ -35,20 +35,25 @@
     <section class="contact-hero">
         <div class="container">
             <h1>Contacto</h1>
-            <p class="contact-intro">Si estás construyendo con ambición y necesitas claridad estratégica, este es el punto de partida.</p>
+            <p class="contact-intro">Si estás evaluando arquitectura mobile, liderazgo técnico, ejecución potenciada por AI o construcción de producto para startup, este es el punto de partida.</p>
         </div>
     </section>
 
     <section class="contact-segmentation">
         <div class="container">
-            <div id="advisor" class="contact-block">
-                <h2>Advisory estratégico</h2>
-                <p>Conversaciones enfocadas en dirección de producto, decisiones estructurales y claridad estratégica en etapas de crecimiento.</p>
+            <div id="architecture" class="contact-block">
+                <h2>Arquitectura Mobile / Liderazgo Técnico</h2>
+                <p>Conversaciones sobre bases mobile nativas, decisiones de arquitectura, calidad de release, sistemas de delivery y necesidades de liderazgo técnico senior.</p>
                 <p class="contact-email"><a href="mailto:contact@matiasrfernandez.com">contact@matiasrfernandez.com</a></p>
             </div>
-            <div id="partnership" class="contact-block">
-                <h2>Partnership en startup</h2>
-                <p>Iniciativas donde producto, arquitectura y dirección requieren involucramiento activo como partner estratégico.</p>
+            <div id="ai" class="contact-block">
+                <h2>AI Solutions / Technical Advisory</h2>
+                <p>Conversaciones enfocadas en adopción práctica de AI, workflows de automatización, documentación técnica, capacidad de ejecución en ingeniería y mejora del delivery.</p>
+                <p class="contact-email"><a href="mailto:contact@matiasrfernandez.com">contact@matiasrfernandez.com</a></p>
+            </div>
+            <div id="startup" class="contact-block">
+                <h2>Advisory Técnico / de Producto para Startups</h2>
+                <p>Iniciativas donde dirección de producto, arquitectura y ejecución necesitan involucramiento activo de un perfil senior que combine producto y ejecución técnica.</p>
                 <p class="contact-email"><a href="mailto:contact@matiasrfernandez.com">contact@matiasrfernandez.com</a></p>
             </div>
             <div id="support" class="contact-block">

--- a/es/index.html
+++ b/es/index.html
@@ -3,23 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Matías Fernández – Senior Product Builder & Advisor</title>
-    <meta name="description" content="Senior Product Builder trabajando en la intersección entre negocio y tecnología. Dirección estratégica, criterio y ejecución real." />
+    <title>Matías Fernández – Arquitectura Mobile, Liderazgo Técnico y Ejecución AI-Enabled</title>
+    <meta name="description" content="Senior technical product builder con más de 14 años en productos mobile y digitales. Arquitectura mobile, liderazgo técnico, ejecución potenciada por AI y productos iOS publicados." />
     <link rel="canonical" href="https://matiasrfernandez.com/es/" />
     <link rel="alternate" hreflang="es" href="https://matiasrfernandez.com/es/" />
     <link rel="alternate" hreflang="en" href="https://matiasrfernandez.com/en/" />
     <link rel="alternate" hreflang="x-default" href="https://matiasrfernandez.com/en/" />
     <!-- Open Graph -->
-    <meta property="og:title" content="Matías Fernández – Senior Product Builder & Advisor" />
-    <meta property="og:description" content="Senior Product Builder trabajando en la intersección entre negocio y tecnología. Dirección estratégica, criterio y ejecución real." />
+    <meta property="og:title" content="Matías Fernández – Arquitectura Mobile, Liderazgo Técnico y Ejecución AI-Enabled" />
+    <meta property="og:description" content="Senior technical product builder con más de 14 años en productos mobile y digitales. Arquitectura mobile, liderazgo técnico, ejecución potenciada por AI y productos iOS publicados." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://matiasrfernandez.com/es/" />
     <meta property="og:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <meta property="og:locale" content="es_ES" />
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Matías Fernández – Senior Product Builder & Advisor" />
-    <meta name="twitter:description" content="Senior Product Builder trabajando en la intersección entre negocio y tecnología. Dirección estratégica, criterio y ejecución real." />
+    <meta name="twitter:title" content="Matías Fernández – Arquitectura Mobile, Liderazgo Técnico y Ejecución AI-Enabled" />
+    <meta name="twitter:description" content="Senior technical product builder con más de 14 años en productos mobile y digitales. Arquitectura mobile, liderazgo técnico, ejecución potenciada por AI y productos iOS publicados." />
     <meta name="twitter:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <link rel="stylesheet" href="../assets/css/style.css">
     <script src="../assets/js/theme.js" defer></script>
@@ -35,12 +35,25 @@
     <main id="top">
         <section class="hero">
             <div class="hero-container">
-                <h1>Construyo y lidero productos digitales con criterio estratégico.</h1>
-                <p class="hero-subtitle">Senior Product Builder y Advisor para startups que quieren escalar con claridad.</p>
-                <p class="hero-description">Trabajo en la intersección entre negocio y tecnología. Tomo decisiones estratégicas, lidero producto y construyo soluciones reales como prueba de ejecución.</p>
+                <h1>Arquitectura mobile, liderazgo técnico y ejecución potenciada por AI.</h1>
+                <p class="hero-subtitle">Ayudo a equipos a construir mejores productos digitales combinando arquitectura mobile, liderazgo técnico y ejecución potenciada por AI.</p>
+                <p class="hero-description">Trabajo en la intersección entre producto, ingeniería y estrategia, con más de 14 años construyendo productos mobile y digitales, liderando equipos técnicos, definiendo arquitectura y llevando ideas a software real.</p>
                 <div class="hero-cta">
-                    <a href="contact/" class="btn-primary">Hablemos de estrategia</a>
+                    <a href="contact/#architecture" class="btn-primary">Hablemos de un rol o proyecto</a>
                     <a href="projects/" class="btn-secondary">Ver proyectos</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="credibility-strip">
+            <div class="container">
+                <h2 class="sr-only">Puntos de credibilidad</h2>
+                <div class="credibility-grid">
+                    <p class="credibility-item">14+ años construyendo productos digitales</p>
+                    <p class="credibility-item">Arquitectura mobile nativa</p>
+                    <p class="credibility-item">Liderazgo técnico y sistemas de delivery</p>
+                    <p class="credibility-item">Productos iOS publicados</p>
+                    <p class="credibility-item">AI y automatización aplicada</p>
                 </div>
             </div>
         </section>
@@ -50,7 +63,7 @@
                 <div class="featured-product-content">
                     <div class="featured-product-text">
                         <h2>Dolar+</h2>
-                        <p class="product-description">Una aplicación enfocada en cotizaciones del dólar en Argentina, diseñada con claridad, precisión y foco en experiencia real de usuario.</p>
+                        <p class="product-description">Dolar+ es un producto iOS nativo para cotizaciones argentinas, construido con SwiftUI, arquitectura modular, APIs de cotización en tiempo real, widgets, integraciones del ecosistema Apple y un enfoque de producto respetuoso con la privacidad.</p>
                         <p class="product-status">Estado: Live</p>
                         <a href="projects/dolarplus/" class="btn-primary">Ver producto</a>
                     </div>
@@ -66,36 +79,50 @@
                 <h2>Qué hago</h2>
                 <div class="what-i-do-grid">
                     <div class="what-i-do-item">
-                        <h3>Estrategia de Producto</h3>
-                        <p>Defino dirección, prioridades y criterios de decisión. Trabajo con foco en impacto real y claridad estratégica, no en listas infinitas de features.</p>
+                        <h3>Arquitectura Mobile y de Producto</h3>
+                        <p>Ayudo a definir la arquitectura de productos mobile y digitales: bases iOS nativas, modularización, APIs, performance, calidad de release y decisiones técnicas sostenibles.</p>
                     </div>
                     <div class="what-i-do-item">
-                        <h3>Liderazgo en la Intersección Negocio-Tecnología</h3>
-                        <p>Conecto visión de negocio con ejecución técnica. Traduzco ambición en roadmap concreto y decisiones sostenibles.</p>
+                        <h3>Liderazgo Técnico y Sistemas de Delivery</h3>
+                        <p>Creo claridad en equipos de ingeniería mediante estándares técnicos, CI/CD, readiness de releases, alineación arquitectónica, mentoring y ejecución cross-functional.</p>
                     </div>
                     <div class="what-i-do-item">
-                        <h3>Construcción como Evidencia</h3>
-                        <p>No solo asesoro. Construyo productos propios para validar criterio, experimentar y mantener contacto real con la ejecución.</p>
+                        <h3>Ejecución Potenciada por AI</h3>
+                        <p>Uso AI y automatización de forma práctica para mejorar discovery, workflows de ingeniería, documentación técnica, velocidad de ejecución y calidad de decisión.</p>
                     </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="how-i-work">
+            <div class="container">
+                <h2>Cómo trabajo</h2>
+                <p class="how-i-work-intro">Combino criterio de producto con ejecución técnica. Aclaro el problema real, defino arquitectura y trade-offs, construyo o guío la primera implementación, creo sistemas de delivery y estándares técnicos, y uso AI cuando mejora velocidad, calidad o capacidad de ejecución.</p>
+                <div class="how-i-work-grid">
+                    <p class="how-i-work-item">Aclaro el problema real de producto y técnico</p>
+                    <p class="how-i-work-item">Defino arquitectura, restricciones y trade-offs</p>
+                    <p class="how-i-work-item">Construyo o guío la implementación</p>
+                    <p class="how-i-work-item">Creo estándares, sistemas de delivery y ciclos de feedback</p>
+                    <p class="how-i-work-item">Aplico AI donde genera ventaja práctica</p>
                 </div>
             </div>
         </section>
 
         <section class="experience-evidence">
             <div class="container">
-                <h2>Experiencia y escala</h2>
+                <h2>Ejecución y credibilidad técnica</h2>
                 <div class="experience-highlights">
                     <div class="experience-item">
-                        <h3>+14 años construyendo producto digital</h3>
-                        <p>He trabajado en entornos corporativos y startups, liderando iniciativas de producto con foco en impacto real y sostenibilidad.</p>
+                        <h3>Arquitectura mobile con contexto de producto</h3>
+                        <p>Trabajo desde las bases nativas de iOS hacia arriba: estructura modular, límites de APIs, calidad de release, performance y los trade-offs que afectan la salud del producto a largo plazo.</p>
                     </div>
                     <div class="experience-item">
-                        <h3>Liderazgo de equipos y decisiones estratégicas</h3>
-                        <p>He participado en decisiones de arquitectura, definición de roadmap, priorización estratégica y coordinación de equipos multidisciplinarios.</p>
+                        <h3>Liderazgo técnico que mejora la ejecución</h3>
+                        <p>Ayudo a crear claridad mediante estándares, CI/CD, readiness de releases, mentoring y alineación cross-functional, para que la ejecución escale sin complejidad innecesaria.</p>
                     </div>
                     <div class="experience-item">
-                        <h3>Visión de largo plazo</h3>
-                        <p>Entiendo el producto como sistema: negocio, tecnología, experiencia y ejecución alineados. Mi foco no es lanzar features, sino construir dirección.</p>
+                        <h3>Software publicado como prueba actual</h3>
+                        <p>Uso productos como Dolar+ para mantenerme cerca de la implementación real, las restricciones de App Store, las decisiones de producto y los detalles que separan una idea de software que funciona.</p>
                     </div>
                 </div>
             </div>
@@ -103,22 +130,22 @@
 
         <section class="strategic-cta">
             <div class="container">
-                <h2>Trabajemos en lo que realmente importa</h2>
+                <h2>Cómo puedo aportar</h2>
                 <div class="cta-grid">
                     <div class="cta-card">
-                        <h3>Advisor Estratégico</h3>
-                        <p>Si estás construyendo una startup y necesitas criterio en producto, dirección estratégica y claridad de decisiones.</p>
-                        <a href="/es/contact/#advisor" class="btn-primary" onclick="gtag('event', 'click_advisory', {'event_category': 'engagement'});">Iniciar conversación</a>
+                        <h3>Staff / Principal / Arquitectura Mobile</h3>
+                        <p>Para equipos que necesitan fortalecer arquitectura mobile nativa, bases técnicas y criterio senior entre producto e ingeniería.</p>
+                        <a href="/es/contact/#architecture" class="btn-primary" onclick="gtag('event', 'click_advisory', {'event_category': 'engagement'});">Hablar de un rol</a>
                     </div>
                     <div class="cta-card">
-                        <h3>Partnership en Startup</h3>
-                        <p>Si buscas un socio con experiencia en producto y ejecución real para construir algo con visión de largo plazo.</p>
-                        <a href="/es/contact/#partnership" class="btn-primary" onclick="gtag('event', 'click_partnership', {'event_category': 'engagement'});">Explorar colaboración</a>
+                        <h3>AI Solutions / Technical Advisory</h3>
+                        <p>Para organizaciones que quieren aplicar AI y automatización a discovery, workflows de ingeniería, documentación técnica y sistemas de delivery.</p>
+                        <a href="/es/contact/#ai" class="btn-primary" onclick="gtag('event', 'click_advisory', {'event_category': 'engagement'});">Hablar de soluciones AI</a>
                     </div>
                     <div class="cta-card">
-                        <h3>Soporte de Aplicaciones</h3>
-                        <p>Si utilizas alguno de mis productos y necesitas asistencia o quieres enviar feedback.</p>
-                        <a href="/es/contact/#support" class="btn-secondary">Ir a soporte</a>
+                        <h3>Advisory Técnico / de Producto para Startups</h3>
+                        <p>Para founders que necesitan un perfil senior que combine producto y ejecución técnica para definir arquitectura, reducir riesgo en decisiones y pasar de concepto a producto publicado.</p>
+                        <a href="/es/contact/#startup" class="btn-secondary" onclick="gtag('event', 'click_partnership', {'event_category': 'engagement'});">Explorar colaboración</a>
                     </div>
                 </div>
             </div>

--- a/es/projects/dolarplus/index.html
+++ b/es/projects/dolarplus/index.html
@@ -43,6 +43,9 @@
                         <a href="https://apps.apple.com/app/id6473115030" class="app-store-link" target="_blank" rel="noopener" onclick="gtag('event', 'click_app_store', {'event_category': 'engagement', 'event_label': 'dolarplus'});">
                             <img class="app-store-badge" src="../../../assets/images/app-store/app-store-badge-es.svg" alt="Descargar en App Store">
                         </a>
+                        <a href="https://www.producthunt.com/products/dolar?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-dollar-2" target="_blank" rel="noopener noreferrer">
+                            <img alt="Dollar+ - The app Argentinians who save in USD have been waiting for. | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1086595&theme=light&t=1772275499785">
+                        </a>
                     </div>
                 </div>
                 <div class="product-hero-image">
@@ -121,11 +124,6 @@
             <div class="container">
                 <h2>Enlaces</h2>
                 <ul class="product-links-list">
-                    <li>
-                        <a href="https://apps.apple.com/app/id6473115030" class="app-store-link" target="_blank" rel="noopener" onclick="gtag('event', 'click_app_store', {'event_category': 'engagement', 'event_label': 'dolarplus'});">
-                            <img class="app-store-badge" src="../../../assets/images/app-store/app-store-badge-es.svg" alt="Descargar en App Store">
-                        </a>
-                    </li>
                     <li><a href="/es/contact/#support">Soporte</a></li>
                     <li><a href="/es/privacy/apps/dolarplus/">Política de privacidad</a></li>
                 </ul>

--- a/es/projects/dolarplus/index.html
+++ b/es/projects/dolarplus/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dolar+ – Producto – Matías Fernández</title>
-    <meta name="description" content="Aplicación iOS de cotizaciones del dólar en Argentina, conversión y seguimiento histórico, diseñada con claridad y precisión." />
+    <meta name="description" content="Producto iOS nativo para cotizaciones argentinas, construido con SwiftUI, arquitectura modular, APIs en tiempo real, widgets y una experiencia de producto enfocada." />
     <link rel="canonical" href="https://matiasrfernandez.com/es/projects/dolarplus/" />
     <link rel="alternate" hreflang="es" href="https://matiasrfernandez.com/es/projects/dolarplus/" />
     <link rel="alternate" hreflang="en" href="https://matiasrfernandez.com/en/projects/dolarplus/" />
     <link rel="alternate" hreflang="x-default" href="https://matiasrfernandez.com/en/projects/dolarplus/" />
     <!-- Open Graph -->
     <meta property="og:title" content="Dolar+ – Producto – Matías Fernández" />
-    <meta property="og:description" content="Aplicación iOS de cotizaciones del dólar en Argentina, conversión y seguimiento histórico, diseñada con claridad y precisión." />
+    <meta property="og:description" content="Producto iOS nativo para cotizaciones argentinas, construido con SwiftUI, arquitectura modular, APIs en tiempo real, widgets y una experiencia de producto enfocada." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://matiasrfernandez.com/es/projects/dolarplus/" />
     <meta property="og:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
@@ -19,7 +19,7 @@
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Dolar+ – Producto – Matías Fernández" />
-    <meta name="twitter:description" content="Aplicación iOS de cotizaciones del dólar en Argentina, conversión y seguimiento histórico, diseñada con claridad y precisión." />
+    <meta name="twitter:description" content="Producto iOS nativo para cotizaciones argentinas, construido con SwiftUI, arquitectura modular, APIs en tiempo real, widgets y una experiencia de producto enfocada." />
     <meta name="twitter:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <link rel="stylesheet" href="../../../assets/css/style.css">
     <script src="../../../assets/js/theme.js" defer></script>
@@ -37,8 +37,8 @@
             <div class="container product-hero-content">
                 <div class="product-hero-text">
                     <h1>Dolar+</h1>
-                    <p class="product-tagline">Cotizaciones del dólar en Argentina con foco en claridad y precisión.</p>
-                    <p class="product-description">Dolar+ nace de la necesidad de acceder rápidamente a tipos de cambio confiables, con una experiencia limpia y sin ruido innecesario.</p>
+                    <p class="product-tagline">Producto iOS nativo para cotizaciones argentinas, construido para claridad, velocidad y uso confiable todos los días.</p>
+                    <p class="product-description">Dolar+ es prueba actual de ejecución nativa en iOS: construido con SwiftUI, arquitectura modular, integraciones de cotización en tiempo real, widgets y un enfoque de producto respetuoso con la privacidad, pensado para decisiones cotidianas.</p>
                     <div class="product-cta">
                         <a href="https://apps.apple.com/app/id6473115030" class="app-store-link" target="_blank" rel="noopener" onclick="gtag('event', 'click_app_store', {'event_category': 'engagement', 'event_label': 'dolarplus'});">
                             <img class="app-store-badge" src="../../../assets/images/app-store/app-store-badge-es.svg" alt="Descargar en App Store">
@@ -73,19 +73,19 @@
         <section class="product-value">
             <div class="container">
                 <h2>Propuesta de valor</h2>
-                <p class="value-intro">Dolar+ fue diseñado priorizando claridad, velocidad y confianza. Cada decisión responde a reducir fricción y eliminar ruido.</p>
+                <p class="value-intro">Dolar+ fue diseñado como un producto nativo enfocado: rápido de leer, técnicamente mantenible y sin ruido innecesario.</p>
                 <div class="value-points">
                     <div class="value-item">
-                        <h3>Claridad sobre volumen</h3>
-                        <p>La interfaz está pensada para mostrar lo esencial sin saturar con datos innecesarios.</p>
+                        <h3>Core flow enfocado</h3>
+                        <p>El producto convierte una consulta financiera repetitiva en una experiencia rápida y legible, en lugar de un dashboard saturado.</p>
                     </div>
                     <div class="value-item">
-                        <h3>Velocidad en la consulta</h3>
-                        <p>El acceso a cotizaciones es inmediato, sin navegación compleja ni pasos adicionales.</p>
+                        <h3>Encaje con el ecosistema nativo</h3>
+                        <p>Widgets e integraciones del ecosistema Apple ponen la información en el contexto correcto, no solo dentro de la app.</p>
                     </div>
                     <div class="value-item">
-                        <h3>Decisiones conscientes</h3>
-                        <p>No incorpora funcionalidades superfluas. El foco está en resolver bien el problema principal antes de expandirse.</p>
+                        <h3>Base técnica sostenible</h3>
+                        <p>La arquitectura favorece límites modulares, flujos de datos claros y decisiones que permiten iterar sin complejidad innecesaria.</p>
                     </div>
                 </div>
             </div>
@@ -104,20 +104,21 @@
         </section>
         <section class="product-stack">
             <div class="container">
-                <h2>Stack técnico</h2>
-                <p class="stack-intro">Dolar+ está construido con foco en simplicidad, mantenibilidad y rendimiento.</p>
+                <h2>Arquitectura y alcance técnico</h2>
+                <p class="stack-intro">Dolar+ está construido como un producto iOS real de producción, con atención a mantenibilidad, performance, calidad de release y encaje con el ecosistema.</p>
                 <ul class="stack-list">
-                    <li>iOS nativo con SwiftUI.</li>
-                    <li>Arquitectura modular enfocada en claridad y testabilidad.</li>
-                    <li>Integración con APIs de cotización en tiempo real.</li>
-                    <li>Widgets y extensiones para el ecosistema Apple.</li>
+                    <li>Aplicación iOS nativa construida con SwiftUI.</li>
+                    <li>Arquitectura modular diseñada para mantenibilidad, límites claros y testabilidad.</li>
+                    <li>Integración con APIs de cotización en tiempo real y normalización de datos.</li>
+                    <li>Widgets e integraciones del ecosistema Apple para acceso rápido y visible.</li>
+                    <li>Decisiones de producto orientadas a mantener una experiencia enfocada, sin ruido innecesario y respetuosa con la privacidad.</li>
                 </ul>
             </div>
         </section>
         <section class="product-status-section">
             <div class="container">
                 <h2>Estado</h2>
-                <p class="product-status-text">Estado actual: Live. Disponible en App Store.</p>
+                <p class="product-status-text">Estado actual: Live en App Store.</p>
             </div>
         </section>
         <section class="product-links">

--- a/es/projects/index.html
+++ b/es/projects/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Proyectos – Matías Fernández</title>
-    <meta name="description" content="Productos propios construidos con criterio estratégico: live, en desarrollo y exploraciones." />
+    <meta name="description" content="Productos que muestran ejecución real: delivery iOS nativo, decisiones técnicas y exploración activa de producto." />
     <link rel="canonical" href="https://matiasrfernandez.com/es/projects/" />
     <link rel="alternate" hreflang="es" href="https://matiasrfernandez.com/es/projects/" />
     <link rel="alternate" hreflang="en" href="https://matiasrfernandez.com/en/projects/" />
     <link rel="alternate" hreflang="x-default" href="https://matiasrfernandez.com/en/projects/" />
     <!-- Open Graph -->
     <meta property="og:title" content="Proyectos – Matías Fernández" />
-    <meta property="og:description" content="Productos propios construidos con criterio estratégico: live, en desarrollo y exploraciones." />
+    <meta property="og:description" content="Productos que muestran ejecución real: delivery iOS nativo, decisiones técnicas y exploración activa de producto." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://matiasrfernandez.com/es/projects/" />
     <meta property="og:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
@@ -19,7 +19,7 @@
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Proyectos – Matías Fernández" />
-    <meta name="twitter:description" content="Productos propios construidos con criterio estratégico: live, en desarrollo y exploraciones." />
+    <meta name="twitter:description" content="Productos que muestran ejecución real: delivery iOS nativo, decisiones técnicas y exploración activa de producto." />
     <meta name="twitter:image" content="https://matiasrfernandez.com/assets/images/og-default.png" />
     <link rel="stylesheet" href="../../assets/css/style.css">
     <script src="../../assets/js/theme.js" defer></script>
@@ -36,7 +36,7 @@
         <section class="projects-intro">
             <div class="container">
                 <h1>Proyectos</h1>
-                <p class="projects-intro-text">Construyo productos propios como extensión natural de mi trabajo en estrategia y liderazgo de producto. Cada proyecto responde a una hipótesis concreta y forma parte de una visión de largo plazo.</p>
+                <p class="projects-intro-text">Construyo productos para mantenerme cerca de la ejecución real. Estos proyectos son donde pongo a prueba criterio de producto, arquitectura mobile y sistemas de delivery en software publicado y exploraciones activas.</p>
             </div>
         </section>
 
@@ -53,11 +53,11 @@
 
                 <section class="projects-section live">
                     <h2>Live</h2>
-                    <p class="projects-section-text">Productos publicados y en uso real.</p>
+                    <p class="projects-section-text">Productos publicados que muestran ejecución técnica actual.</p>
                     <div class="projects-grid live-grid">
                         <div class="project-card">
                             <h3 class="project-title">Dolar+</h3>
-                            <p class="project-description">Aplicación iOS enfocada en cotizaciones del dólar en Argentina, conversión y seguimiento histórico.</p>
+                            <p class="project-description">Producto iOS nativo para cotizaciones argentinas, construido con SwiftUI, arquitectura modular, APIs en tiempo real, widgets y seguimiento histórico.</p>
                             <p class="project-status project-status--live">Live</p>
                             <a href="/es/projects/dolarplus/" class="project-link">Ver producto</a>
                         </div>
@@ -66,11 +66,11 @@
 
                 <section class="projects-section in-progress">
                     <h2>En desarrollo</h2>
-                    <p class="projects-section-text">Iniciativas activas en construcción.</p>
+                    <p class="projects-section-text">Iniciativas activas donde todavía se está definiendo dirección de producto y base técnica.</p>
                     <div class="projects-grid progress-grid">
                         <div class="project-card">
                             <h3 class="project-title">Próximo Producto</h3>
-                            <p class="project-description">Iniciativa en desarrollo con foco en resolver problemas reales a través de producto digital.</p>
+                            <p class="project-description">Iniciativa en desarrollo enfocada en resolver problemas reales mediante producto, arquitectura y ejecución práctica.</p>
                             <p class="project-status">En desarrollo</p>
                         </div>
                     </div>
@@ -78,11 +78,11 @@
 
                 <section class="projects-section explorations">
                     <h2>Exploraciones</h2>
-                    <p class="projects-section-text">Hipótesis en evaluación y experimentación.</p>
+                    <p class="projects-section-text">Hipótesis evaluadas mediante pensamiento de producto, exploración técnica y experimentación.</p>
                     <div class="projects-grid exploration-grid">
                         <div class="project-card">
                             <h3 class="project-title">Exploración en curso</h3>
-                            <p class="project-description">Hipótesis de producto en evaluación estratégica y validación conceptual.</p>
+                            <p class="project-description">Hipótesis de producto en evaluación a través de framing técnico, validación conceptual y pensamiento temprano de ejecución.</p>
                             <p class="project-status">Exploración</p>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- reposition the English and Spanish site messaging toward mobile architecture, technical leadership, and AI-enabled execution
- add homepage credibility and working-method sections without changing the overall visual direction
- strengthen Dolar+ and project/about/contact copy so the new positioning stays consistent across the site

## Why
The site was still centered on broad strategic-advisor language. This change reframes the profile around senior technical product building, native mobile depth, and practical AI-enabled delivery.

## Validation
- manually reviewed `/en/` in desktop view
- manually reviewed `/es/` in desktop view
- manually reviewed `/es/` at mobile width `390x844`
- verified the homepage CTA path to `/en/contact/#architecture`
- manually reviewed `/en/projects/dolarplus/`
- confirmed no relevant console warnings or errors during those checks